### PR TITLE
Feature/add sort by starttime

### DIFF
--- a/api/proto/racing/racing.pb.go
+++ b/api/proto/racing/racing.pb.go
@@ -7,13 +7,14 @@
 package racing
 
 import (
+	reflect "reflect"
+	sync "sync"
+	unsafe "unsafe"
+
 	_ "google.golang.org/genproto/googleapis/api/annotations"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
-	reflect "reflect"
-	sync "sync"
-	unsafe "unsafe"
 )
 
 const (
@@ -22,6 +23,56 @@ const (
 	// Verify that runtime/protoimpl is sufficiently up-to-date.
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
+
+// Define enumeration for sorting direction
+type SortDirection int32
+
+const (
+	SortDirection_SORT_DIRECTION_UNSPECIFIED SortDirection = 0 // The default, or 'unspecified', value.
+	SortDirection_SORT_DIRECTION_ASC         SortDirection = 1 // Ascending order.
+	SortDirection_SORT_DIRECTION_DESC        SortDirection = 2 // Descending order.
+)
+
+// Enum value maps for SortDirection.
+var (
+	SortDirection_name = map[int32]string{
+		0: "SORT_DIRECTION_UNSPECIFIED",
+		1: "SORT_DIRECTION_ASC",
+		2: "SORT_DIRECTION_DESC",
+	}
+	SortDirection_value = map[string]int32{
+		"SORT_DIRECTION_UNSPECIFIED": 0,
+		"SORT_DIRECTION_ASC":         1,
+		"SORT_DIRECTION_DESC":        2,
+	}
+)
+
+func (x SortDirection) Enum() *SortDirection {
+	p := new(SortDirection)
+	*p = x
+	return p
+}
+
+func (x SortDirection) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (SortDirection) Descriptor() protoreflect.EnumDescriptor {
+	return file_racing_racing_proto_enumTypes[0].Descriptor()
+}
+
+func (SortDirection) Type() protoreflect.EnumType {
+	return &file_racing_racing_proto_enumTypes[0]
+}
+
+func (x SortDirection) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use SortDirection.Descriptor instead.
+func (SortDirection) EnumDescriptor() ([]byte, []int) {
+	return file_racing_racing_proto_rawDescGZIP(), []int{0}
+}
 
 // Request for ListRaces call.
 type ListRacesRequest struct {
@@ -118,6 +169,7 @@ type ListRacesRequestFilter struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	MeetingIds    []int64                `protobuf:"varint,1,rep,packed,name=meeting_ids,json=meetingIds,proto3" json:"meeting_ids,omitempty"`
 	Visible       *bool                  `protobuf:"varint,2,opt,name=visible,proto3,oneof" json:"visible,omitempty"`
+	SortDirection *SortDirection         `protobuf:"varint,3,opt,name=sort_direction,json=sortDirection,proto3,enum=racing.SortDirection,oneof" json:"sort_direction,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -164,6 +216,13 @@ func (x *ListRacesRequestFilter) GetVisible() bool {
 		return *x.Visible
 	}
 	return false
+}
+
+func (x *ListRacesRequestFilter) GetSortDirection() SortDirection {
+	if x != nil && x.SortDirection != nil {
+		return *x.SortDirection
+	}
+	return SortDirection_SORT_DIRECTION_UNSPECIFIED
 }
 
 // A race resource.
@@ -265,13 +324,15 @@ const file_racing_racing_proto_rawDesc = "" +
 	"\x10ListRacesRequest\x126\n" +
 	"\x06filter\x18\x01 \x01(\v2\x1e.racing.ListRacesRequestFilterR\x06filter\"7\n" +
 	"\x11ListRacesResponse\x12\"\n" +
-	"\x05races\x18\x01 \x03(\v2\f.racing.RaceR\x05races\"d\n" +
+	"\x05races\x18\x01 \x03(\v2\f.racing.RaceR\x05races\"\xba\x01\n" +
 	"\x16ListRacesRequestFilter\x12\x1f\n" +
 	"\vmeeting_ids\x18\x01 \x03(\x03R\n" +
 	"meetingIds\x12\x1d\n" +
-	"\avisible\x18\x02 \x01(\bH\x00R\avisible\x88\x01\x01B\n" +
+	"\avisible\x18\x02 \x01(\bH\x00R\avisible\x88\x01\x01\x12A\n" +
+	"\x0esort_direction\x18\x03 \x01(\x0e2\x15.racing.SortDirectionH\x01R\rsortDirection\x88\x01\x01B\n" +
 	"\n" +
-	"\b_visible\"\xcb\x01\n" +
+	"\b_visibleB\x11\n" +
+	"\x0f_sort_direction\"\xcb\x01\n" +
 	"\x04Race\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\x03R\x02id\x12\x1d\n" +
 	"\n" +
@@ -279,7 +340,11 @@ const file_racing_racing_proto_rawDesc = "" +
 	"\x04name\x18\x03 \x01(\tR\x04name\x12\x16\n" +
 	"\x06number\x18\x04 \x01(\x03R\x06number\x12\x18\n" +
 	"\avisible\x18\x05 \x01(\bR\avisible\x12N\n" +
-	"\x15advertised_start_time\x18\x06 \x01(\v2\x1a.google.protobuf.TimestampR\x13advertisedStartTime2e\n" +
+	"\x15advertised_start_time\x18\x06 \x01(\v2\x1a.google.protobuf.TimestampR\x13advertisedStartTime*`\n" +
+	"\rSortDirection\x12\x1e\n" +
+	"\x1aSORT_DIRECTION_UNSPECIFIED\x10\x00\x12\x16\n" +
+	"\x12SORT_DIRECTION_ASC\x10\x01\x12\x17\n" +
+	"\x13SORT_DIRECTION_DESC\x10\x022e\n" +
 	"\x06Racing\x12[\n" +
 	"\tListRaces\x12\x18.racing.ListRacesRequest\x1a\x19.racing.ListRacesResponse\"\x19\x82\xd3\xe4\x93\x02\x13:\x01*\"\x0e/v1/list-racesB\tZ\a/racingb\x06proto3"
 
@@ -295,25 +360,28 @@ func file_racing_racing_proto_rawDescGZIP() []byte {
 	return file_racing_racing_proto_rawDescData
 }
 
+var file_racing_racing_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
 var file_racing_racing_proto_msgTypes = make([]protoimpl.MessageInfo, 4)
 var file_racing_racing_proto_goTypes = []any{
-	(*ListRacesRequest)(nil),       // 0: racing.ListRacesRequest
-	(*ListRacesResponse)(nil),      // 1: racing.ListRacesResponse
-	(*ListRacesRequestFilter)(nil), // 2: racing.ListRacesRequestFilter
-	(*Race)(nil),                   // 3: racing.Race
-	(*timestamppb.Timestamp)(nil),  // 4: google.protobuf.Timestamp
+	(SortDirection)(0),             // 0: racing.SortDirection
+	(*ListRacesRequest)(nil),       // 1: racing.ListRacesRequest
+	(*ListRacesResponse)(nil),      // 2: racing.ListRacesResponse
+	(*ListRacesRequestFilter)(nil), // 3: racing.ListRacesRequestFilter
+	(*Race)(nil),                   // 4: racing.Race
+	(*timestamppb.Timestamp)(nil),  // 5: google.protobuf.Timestamp
 }
 var file_racing_racing_proto_depIdxs = []int32{
-	2, // 0: racing.ListRacesRequest.filter:type_name -> racing.ListRacesRequestFilter
-	3, // 1: racing.ListRacesResponse.races:type_name -> racing.Race
-	4, // 2: racing.Race.advertised_start_time:type_name -> google.protobuf.Timestamp
-	0, // 3: racing.Racing.ListRaces:input_type -> racing.ListRacesRequest
-	1, // 4: racing.Racing.ListRaces:output_type -> racing.ListRacesResponse
-	4, // [4:5] is the sub-list for method output_type
-	3, // [3:4] is the sub-list for method input_type
-	3, // [3:3] is the sub-list for extension type_name
-	3, // [3:3] is the sub-list for extension extendee
-	0, // [0:3] is the sub-list for field type_name
+	3, // 0: racing.ListRacesRequest.filter:type_name -> racing.ListRacesRequestFilter
+	4, // 1: racing.ListRacesResponse.races:type_name -> racing.Race
+	0, // 2: racing.ListRacesRequestFilter.sort_direction:type_name -> racing.SortDirection
+	5, // 3: racing.Race.advertised_start_time:type_name -> google.protobuf.Timestamp
+	1, // 4: racing.Racing.ListRaces:input_type -> racing.ListRacesRequest
+	2, // 5: racing.Racing.ListRaces:output_type -> racing.ListRacesResponse
+	5, // [5:6] is the sub-list for method output_type
+	4, // [4:5] is the sub-list for method input_type
+	4, // [4:4] is the sub-list for extension type_name
+	4, // [4:4] is the sub-list for extension extendee
+	0, // [0:4] is the sub-list for field type_name
 }
 
 func init() { file_racing_racing_proto_init() }
@@ -327,13 +395,14 @@ func file_racing_racing_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_racing_racing_proto_rawDesc), len(file_racing_racing_proto_rawDesc)),
-			NumEnums:      0,
+			NumEnums:      1,
 			NumMessages:   4,
 			NumExtensions: 0,
 			NumServices:   1,
 		},
 		GoTypes:           file_racing_racing_proto_goTypes,
 		DependencyIndexes: file_racing_racing_proto_depIdxs,
+		EnumInfos:         file_racing_racing_proto_enumTypes,
 		MessageInfos:      file_racing_racing_proto_msgTypes,
 	}.Build()
 	File_racing_racing_proto = out.File

--- a/api/proto/racing/racing.proto
+++ b/api/proto/racing/racing.proto
@@ -13,6 +13,13 @@ service Racing {
   }
 }
 
+// Define enumeration for sorting direction
+enum SortDirection {
+  SORT_DIRECTION_UNSPECIFIED = 0; // The default, or 'unspecified', value.
+  SORT_DIRECTION_ASC = 1;         // Ascending order.
+  SORT_DIRECTION_DESC = 2;        // Descending order.
+}
+
 /* Requests/Responses */
 
 // Request for ListRaces call.
@@ -29,6 +36,7 @@ message ListRacesResponse {
 message ListRacesRequestFilter {
   repeated int64 meeting_ids = 1;
   optional bool visible = 2;
+  optional SortDirection sort_direction = 3;
 }
 
 /* Resources */

--- a/racing/db/races.go
+++ b/racing/db/races.go
@@ -94,6 +94,26 @@ func (r *racesRepo) applyFilter(query string, filter *racing.ListRacesRequestFil
 		query += " WHERE " + strings.Join(clauses, " AND ")
 	}
 
+	// Order filter.
+	// This allows the user to sort the rows by advertised start time,
+	// Ascending, or Descending.
+	// ORDER BY date_column DESC;
+	// Note: This clause MUST be after the WHERE, and any HAVING, clauses, but
+	// before any LIMIT or OFFSET clauses.
+	// Other order by clauses for different fields can be added here too.
+	// Finally: advertisedStartTime is hard coded here, but there's no reason
+	// that it cannot be another variable passed in by the user.
+	if filter.SortDirection != nil {
+		direction := ""
+		switch *filter.SortDirection {
+		case 1:
+			direction = " ORDER BY advertised_start_time ASC"
+		case 2:
+			direction = " ORDER BY advertised_start_time DESC"
+		}
+		query += direction
+	}
+
 	return query, args
 }
 

--- a/racing/proto/racing/racing.pb.go
+++ b/racing/proto/racing/racing.pb.go
@@ -22,6 +22,56 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
+// Define enumeration for sorting direction
+type SortDirection int32
+
+const (
+	SortDirection_SORT_DIRECTION_UNSPECIFIED SortDirection = 0 // The default, or 'unspecified', value.
+	SortDirection_SORT_DIRECTION_ASC         SortDirection = 1 // Ascending order.
+	SortDirection_SORT_DIRECTION_DESC        SortDirection = 2 // Descending order.
+)
+
+// Enum value maps for SortDirection.
+var (
+	SortDirection_name = map[int32]string{
+		0: "SORT_DIRECTION_UNSPECIFIED",
+		1: "SORT_DIRECTION_ASC",
+		2: "SORT_DIRECTION_DESC",
+	}
+	SortDirection_value = map[string]int32{
+		"SORT_DIRECTION_UNSPECIFIED": 0,
+		"SORT_DIRECTION_ASC":         1,
+		"SORT_DIRECTION_DESC":        2,
+	}
+)
+
+func (x SortDirection) Enum() *SortDirection {
+	p := new(SortDirection)
+	*p = x
+	return p
+}
+
+func (x SortDirection) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (SortDirection) Descriptor() protoreflect.EnumDescriptor {
+	return file_racing_racing_proto_enumTypes[0].Descriptor()
+}
+
+func (SortDirection) Type() protoreflect.EnumType {
+	return &file_racing_racing_proto_enumTypes[0]
+}
+
+func (x SortDirection) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use SortDirection.Descriptor instead.
+func (SortDirection) EnumDescriptor() ([]byte, []int) {
+	return file_racing_racing_proto_rawDescGZIP(), []int{0}
+}
+
 type ListRacesRequest struct {
 	state         protoimpl.MessageState  `protogen:"open.v1"`
 	Filter        *ListRacesRequestFilter `protobuf:"bytes,1,opt,name=filter,proto3" json:"filter,omitempty"`
@@ -277,7 +327,11 @@ const file_racing_racing_proto_rawDesc = "" +
 	"\x04name\x18\x03 \x01(\tR\x04name\x12\x16\n" +
 	"\x06number\x18\x04 \x01(\x03R\x06number\x12\x18\n" +
 	"\avisible\x18\x05 \x01(\bR\avisible\x12N\n" +
-	"\x15advertised_start_time\x18\x06 \x01(\v2\x1a.google.protobuf.TimestampR\x13advertisedStartTime2L\n" +
+	"\x15advertised_start_time\x18\x06 \x01(\v2\x1a.google.protobuf.TimestampR\x13advertisedStartTime*`\n" +
+	"\rSortDirection\x12\x1e\n" +
+	"\x1aSORT_DIRECTION_UNSPECIFIED\x10\x00\x12\x16\n" +
+	"\x12SORT_DIRECTION_ASC\x10\x01\x12\x17\n" +
+	"\x13SORT_DIRECTION_DESC\x10\x022L\n" +
 	"\x06Racing\x12B\n" +
 	"\tListRaces\x12\x18.racing.ListRacesRequest\x1a\x19.racing.ListRacesResponse\"\x00B\tZ\a/racingb\x06proto3"
 
@@ -293,20 +347,22 @@ func file_racing_racing_proto_rawDescGZIP() []byte {
 	return file_racing_racing_proto_rawDescData
 }
 
+var file_racing_racing_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
 var file_racing_racing_proto_msgTypes = make([]protoimpl.MessageInfo, 4)
 var file_racing_racing_proto_goTypes = []any{
-	(*ListRacesRequest)(nil),       // 0: racing.ListRacesRequest
-	(*ListRacesResponse)(nil),      // 1: racing.ListRacesResponse
-	(*ListRacesRequestFilter)(nil), // 2: racing.ListRacesRequestFilter
-	(*Race)(nil),                   // 3: racing.Race
-	(*timestamppb.Timestamp)(nil),  // 4: google.protobuf.Timestamp
+	(SortDirection)(0),             // 0: racing.SortDirection
+	(*ListRacesRequest)(nil),       // 1: racing.ListRacesRequest
+	(*ListRacesResponse)(nil),      // 2: racing.ListRacesResponse
+	(*ListRacesRequestFilter)(nil), // 3: racing.ListRacesRequestFilter
+	(*Race)(nil),                   // 4: racing.Race
+	(*timestamppb.Timestamp)(nil),  // 5: google.protobuf.Timestamp
 }
 var file_racing_racing_proto_depIdxs = []int32{
-	2, // 0: racing.ListRacesRequest.filter:type_name -> racing.ListRacesRequestFilter
-	3, // 1: racing.ListRacesResponse.races:type_name -> racing.Race
-	4, // 2: racing.Race.advertised_start_time:type_name -> google.protobuf.Timestamp
-	0, // 3: racing.Racing.ListRaces:input_type -> racing.ListRacesRequest
-	1, // 4: racing.Racing.ListRaces:output_type -> racing.ListRacesResponse
+	3, // 0: racing.ListRacesRequest.filter:type_name -> racing.ListRacesRequestFilter
+	4, // 1: racing.ListRacesResponse.races:type_name -> racing.Race
+	5, // 2: racing.Race.advertised_start_time:type_name -> google.protobuf.Timestamp
+	1, // 3: racing.Racing.ListRaces:input_type -> racing.ListRacesRequest
+	2, // 4: racing.Racing.ListRaces:output_type -> racing.ListRacesResponse
 	4, // [4:5] is the sub-list for method output_type
 	3, // [3:4] is the sub-list for method input_type
 	3, // [3:3] is the sub-list for extension type_name
@@ -325,13 +381,14 @@ func file_racing_racing_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_racing_racing_proto_rawDesc), len(file_racing_racing_proto_rawDesc)),
-			NumEnums:      0,
+			NumEnums:      1,
 			NumMessages:   4,
 			NumExtensions: 0,
 			NumServices:   1,
 		},
 		GoTypes:           file_racing_racing_proto_goTypes,
 		DependencyIndexes: file_racing_racing_proto_depIdxs,
+		EnumInfos:         file_racing_racing_proto_enumTypes,
 		MessageInfos:      file_racing_racing_proto_msgTypes,
 	}.Build()
 	File_racing_racing_proto = out.File

--- a/racing/proto/racing/racing.pb.go
+++ b/racing/proto/racing/racing.pb.go
@@ -166,6 +166,7 @@ type ListRacesRequestFilter struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	MeetingIds    []int64                `protobuf:"varint,1,rep,packed,name=meeting_ids,json=meetingIds,proto3" json:"meeting_ids,omitempty"`
 	Visible       *bool                  `protobuf:"varint,2,opt,name=visible,proto3,oneof" json:"visible,omitempty"`
+	SortDirection *SortDirection         `protobuf:"varint,3,opt,name=sort_direction,json=sortDirection,proto3,enum=racing.SortDirection,oneof" json:"sort_direction,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -212,6 +213,13 @@ func (x *ListRacesRequestFilter) GetVisible() bool {
 		return *x.Visible
 	}
 	return false
+}
+
+func (x *ListRacesRequestFilter) GetSortDirection() SortDirection {
+	if x != nil && x.SortDirection != nil {
+		return *x.SortDirection
+	}
+	return SortDirection_SORT_DIRECTION_UNSPECIFIED
 }
 
 // A race resource.
@@ -313,13 +321,15 @@ const file_racing_racing_proto_rawDesc = "" +
 	"\x10ListRacesRequest\x126\n" +
 	"\x06filter\x18\x01 \x01(\v2\x1e.racing.ListRacesRequestFilterR\x06filter\"7\n" +
 	"\x11ListRacesResponse\x12\"\n" +
-	"\x05races\x18\x01 \x03(\v2\f.racing.RaceR\x05races\"d\n" +
+	"\x05races\x18\x01 \x03(\v2\f.racing.RaceR\x05races\"\xba\x01\n" +
 	"\x16ListRacesRequestFilter\x12\x1f\n" +
 	"\vmeeting_ids\x18\x01 \x03(\x03R\n" +
 	"meetingIds\x12\x1d\n" +
-	"\avisible\x18\x02 \x01(\bH\x00R\avisible\x88\x01\x01B\n" +
+	"\avisible\x18\x02 \x01(\bH\x00R\avisible\x88\x01\x01\x12A\n" +
+	"\x0esort_direction\x18\x03 \x01(\x0e2\x15.racing.SortDirectionH\x01R\rsortDirection\x88\x01\x01B\n" +
 	"\n" +
-	"\b_visible\"\xcb\x01\n" +
+	"\b_visibleB\x11\n" +
+	"\x0f_sort_direction\"\xcb\x01\n" +
 	"\x04Race\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\x03R\x02id\x12\x1d\n" +
 	"\n" +
@@ -360,14 +370,15 @@ var file_racing_racing_proto_goTypes = []any{
 var file_racing_racing_proto_depIdxs = []int32{
 	3, // 0: racing.ListRacesRequest.filter:type_name -> racing.ListRacesRequestFilter
 	4, // 1: racing.ListRacesResponse.races:type_name -> racing.Race
-	5, // 2: racing.Race.advertised_start_time:type_name -> google.protobuf.Timestamp
-	1, // 3: racing.Racing.ListRaces:input_type -> racing.ListRacesRequest
-	2, // 4: racing.Racing.ListRaces:output_type -> racing.ListRacesResponse
-	4, // [4:5] is the sub-list for method output_type
-	3, // [3:4] is the sub-list for method input_type
-	3, // [3:3] is the sub-list for extension type_name
-	3, // [3:3] is the sub-list for extension extendee
-	0, // [0:3] is the sub-list for field type_name
+	0, // 2: racing.ListRacesRequestFilter.sort_direction:type_name -> racing.SortDirection
+	5, // 3: racing.Race.advertised_start_time:type_name -> google.protobuf.Timestamp
+	1, // 4: racing.Racing.ListRaces:input_type -> racing.ListRacesRequest
+	2, // 5: racing.Racing.ListRaces:output_type -> racing.ListRacesResponse
+	5, // [5:6] is the sub-list for method output_type
+	4, // [4:5] is the sub-list for method input_type
+	4, // [4:4] is the sub-list for extension type_name
+	4, // [4:4] is the sub-list for extension extendee
+	0, // [0:4] is the sub-list for field type_name
 }
 
 func init() { file_racing_racing_proto_init() }

--- a/racing/proto/racing/racing.proto
+++ b/racing/proto/racing/racing.proto
@@ -32,6 +32,7 @@ message ListRacesResponse {
 message ListRacesRequestFilter {
   repeated int64 meeting_ids = 1;
   optional bool visible = 2;
+  optional SortDirection sort_direction = 3;
 }
 
 /* Resources */

--- a/racing/proto/racing/racing.proto
+++ b/racing/proto/racing/racing.proto
@@ -10,6 +10,13 @@ service Racing {
   rpc ListRaces(ListRacesRequest) returns (ListRacesResponse) {}
 }
 
+// Define enumeration for sorting direction
+enum SortDirection {
+  SORT_DIRECTION_UNSPECIFIED = 0; // The default, or 'unspecified', value.
+  SORT_DIRECTION_ASC = 1;         // Ascending order.
+  SORT_DIRECTION_DESC = 2;        // Descending order.
+}
+
 /* Requests/Responses */
 
 message ListRacesRequest {


### PR DESCRIPTION
This change introduces the optional ability to order the races by their advertised start time.

The user can specify "Ascending" or "Descending" for the rdering (by using the integers 1, or 2, respectively)

By adding a filter attribute "sort_direction" and passing a value of 1, or 2, to the query sent to the list-races endpoint, the results will be ordered as requested.

Example testing:

Get all of the races, sort them by their advertised start time descending, and only output the start time
```bash
$ curl -X "POST" "http://localhost:8000/v1/list-races"      -H 'Content-Type: application/json'      -d $'{
  "filter": {"sort_direction":2 }
}' | jq '.races[] | .advertisedStartTime'
```

Or get all of the races, sorted by their advertised start tie ascending.
```bash
$ curl -X "POST" "http://localhost:8000/v1/list-races"      -H 'Content-Type: application/json'      -d $'{
  "filter": {"sort_direction":1 }
}'
```

Note that the sort direction is `0` for unsorted, `1` for `Ascending`, and `2` for `Descending`.

An enumeration was used which forced the use of integers. This ensures that the values passed in aren't going to cause any problems when they are handled.

as with `visible` `sort_direction` is an optional field.