### PR TITLE
Feature/add new status field

### DIFF
--- a/api/proto/racing/racing.pb.go
+++ b/api/proto/racing/racing.pb.go
@@ -240,8 +240,10 @@ type Race struct {
 	Visible bool `protobuf:"varint,5,opt,name=visible,proto3" json:"visible,omitempty"`
 	// AdvertisedStartTime is the time the race is advertised to run.
 	AdvertisedStartTime *timestamppb.Timestamp `protobuf:"bytes,6,opt,name=advertised_start_time,json=advertisedStartTime,proto3" json:"advertised_start_time,omitempty"`
-	unknownFields       protoimpl.UnknownFields
-	sizeCache           protoimpl.SizeCache
+	// Status is whether a race is OPEN or CLOSED.
+	Status        string `protobuf:"bytes,7,opt,name=status,proto3" json:"status,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *Race) Reset() {
@@ -316,6 +318,13 @@ func (x *Race) GetAdvertisedStartTime() *timestamppb.Timestamp {
 	return nil
 }
 
+func (x *Race) GetStatus() string {
+	if x != nil {
+		return x.Status
+	}
+	return ""
+}
+
 var File_racing_racing_proto protoreflect.FileDescriptor
 
 const file_racing_racing_proto_rawDesc = "" +
@@ -332,7 +341,7 @@ const file_racing_racing_proto_rawDesc = "" +
 	"\x0esort_direction\x18\x03 \x01(\x0e2\x15.racing.SortDirectionH\x01R\rsortDirection\x88\x01\x01B\n" +
 	"\n" +
 	"\b_visibleB\x11\n" +
-	"\x0f_sort_direction\"\xcb\x01\n" +
+	"\x0f_sort_direction\"\xe3\x01\n" +
 	"\x04Race\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\x03R\x02id\x12\x1d\n" +
 	"\n" +
@@ -340,7 +349,8 @@ const file_racing_racing_proto_rawDesc = "" +
 	"\x04name\x18\x03 \x01(\tR\x04name\x12\x16\n" +
 	"\x06number\x18\x04 \x01(\x03R\x06number\x12\x18\n" +
 	"\avisible\x18\x05 \x01(\bR\avisible\x12N\n" +
-	"\x15advertised_start_time\x18\x06 \x01(\v2\x1a.google.protobuf.TimestampR\x13advertisedStartTime*`\n" +
+	"\x15advertised_start_time\x18\x06 \x01(\v2\x1a.google.protobuf.TimestampR\x13advertisedStartTime\x12\x16\n" +
+	"\x06status\x18\a \x01(\tR\x06status*`\n" +
 	"\rSortDirection\x12\x1e\n" +
 	"\x1aSORT_DIRECTION_UNSPECIFIED\x10\x00\x12\x16\n" +
 	"\x12SORT_DIRECTION_ASC\x10\x01\x12\x17\n" +

--- a/api/proto/racing/racing.proto
+++ b/api/proto/racing/racing.proto
@@ -55,4 +55,6 @@ message Race {
   bool visible = 5;
   // AdvertisedStartTime is the time the race is advertised to run.
   google.protobuf.Timestamp advertised_start_time = 6;
+  // Status is whether a race is OPEN or CLOSED.
+  string status = 7;
 }

--- a/racing/db/races.go
+++ b/racing/db/races.go
@@ -117,6 +117,10 @@ func (r *racesRepo) applyFilter(query string, filter *racing.ListRacesRequestFil
 	return query, args
 }
 
+// testableTimeNow - this can be overriden by a test in the same package,
+// allowing deterministic testing without having to manipulate the race data.
+var testableTimeNow = time.Now
+
 func (m *racesRepo) scanRaces(
 	rows *sql.Rows,
 ) ([]*racing.Race, error) {
@@ -140,6 +144,17 @@ func (m *racesRepo) scanRaces(
 		}
 
 		race.AdvertisedStartTime = ts
+
+		// Set race status as open or closed.
+		// A race is closed if its advertised starttime has passed.
+		// Note: the cut off time is hardcoded to Now, but there's no reason
+		// that it couldn't be passed in as a variable if desired.
+		status := "OPEN"
+		if advertisedStart.Before(testableTimeNow()) {
+			status = "CLOSED"
+		}
+
+		race.Status = status
 
 		races = append(races, &race)
 	}

--- a/racing/proto/racing/racing.pb.go
+++ b/racing/proto/racing/racing.pb.go
@@ -237,8 +237,10 @@ type Race struct {
 	Visible bool `protobuf:"varint,5,opt,name=visible,proto3" json:"visible,omitempty"`
 	// AdvertisedStartTime is the time the race is advertised to run.
 	AdvertisedStartTime *timestamppb.Timestamp `protobuf:"bytes,6,opt,name=advertised_start_time,json=advertisedStartTime,proto3" json:"advertised_start_time,omitempty"`
-	unknownFields       protoimpl.UnknownFields
-	sizeCache           protoimpl.SizeCache
+	// Status is whether a race is OPEN or CLOSED.
+	Status        string `protobuf:"bytes,7,opt,name=status,proto3" json:"status,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *Race) Reset() {
@@ -313,6 +315,13 @@ func (x *Race) GetAdvertisedStartTime() *timestamppb.Timestamp {
 	return nil
 }
 
+func (x *Race) GetStatus() string {
+	if x != nil {
+		return x.Status
+	}
+	return ""
+}
+
 var File_racing_racing_proto protoreflect.FileDescriptor
 
 const file_racing_racing_proto_rawDesc = "" +
@@ -329,7 +338,7 @@ const file_racing_racing_proto_rawDesc = "" +
 	"\x0esort_direction\x18\x03 \x01(\x0e2\x15.racing.SortDirectionH\x01R\rsortDirection\x88\x01\x01B\n" +
 	"\n" +
 	"\b_visibleB\x11\n" +
-	"\x0f_sort_direction\"\xcb\x01\n" +
+	"\x0f_sort_direction\"\xe3\x01\n" +
 	"\x04Race\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\x03R\x02id\x12\x1d\n" +
 	"\n" +
@@ -337,7 +346,8 @@ const file_racing_racing_proto_rawDesc = "" +
 	"\x04name\x18\x03 \x01(\tR\x04name\x12\x16\n" +
 	"\x06number\x18\x04 \x01(\x03R\x06number\x12\x18\n" +
 	"\avisible\x18\x05 \x01(\bR\avisible\x12N\n" +
-	"\x15advertised_start_time\x18\x06 \x01(\v2\x1a.google.protobuf.TimestampR\x13advertisedStartTime*`\n" +
+	"\x15advertised_start_time\x18\x06 \x01(\v2\x1a.google.protobuf.TimestampR\x13advertisedStartTime\x12\x16\n" +
+	"\x06status\x18\a \x01(\tR\x06status*`\n" +
 	"\rSortDirection\x12\x1e\n" +
 	"\x1aSORT_DIRECTION_UNSPECIFIED\x10\x00\x12\x16\n" +
 	"\x12SORT_DIRECTION_ASC\x10\x01\x12\x17\n" +

--- a/racing/proto/racing/racing.proto
+++ b/racing/proto/racing/racing.proto
@@ -51,5 +51,6 @@ message Race {
   bool visible = 5;
   // AdvertisedStartTime is the time the race is advertised to run.
   google.protobuf.Timestamp advertised_start_time = 6;
+  // Status is whether a race is OPEN or CLOSED.
+  string status = 7;
 }
-


### PR DESCRIPTION
This changes introduces the addition of a "status" field to the races data.

The following will demonstrate the seeing value of the `status` field:

```bash
$ curl -X "POST" "http://localhost:8000/v1/list-races"      -H 'Content-Type: application/json'      -d $'{
  "filter": {}
}' | jq '.races[] | .status'
```

Currently the code uses `time/Now()` to determine whether a race has already been started, or not. If no new data is being used for tests, then 
 https://github.com/shaneHowearth/entain/blob/69d788559c8a1715e645b5cb5af820b91c8b37a9/racing/db/races.go#L122

can be changed to return a `time/Time` of the testers choosing

Something like the following would mean that races before 3 pm on February the 28th 2021 (UTC) will be closed, and all others will be open

```Go
var testableTimeNow = func(){
    t, _ := time.Parse(time.RFC3339, "2021-02-28T15:00:00Z")
    return t
}
```