### PR TITLE
Use go1.20 in go.mod

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -1,12 +1,22 @@
 module git.neds.sh/matty/entain/api
 
-go 1.16
+go 1.20
 
 require (
 	github.com/golang/protobuf v1.4.3
+	github.com/grpc-ecosystem/grpc-gateway v1.9.0
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.3.0
 	google.golang.org/genproto v0.0.0-20210226172003-ab064af71705
 	google.golang.org/grpc v1.36.0
 	google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.1.0
 	google.golang.org/protobuf v1.25.1-0.20201208041424-160c7477e0e8
+)
+
+require (
+	github.com/ghodss/yaml v1.0.0 // indirect
+	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b // indirect
+	golang.org/x/net v0.0.0-20210119194325-5f4716e94777 // indirect
+	golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c // indirect
+	golang.org/x/text v0.3.5 // indirect
+	gopkg.in/yaml.v2 v2.3.0 // indirect
 )

--- a/racing/db/queries.go
+++ b/racing/db/queries.go
@@ -7,13 +7,13 @@ const (
 func getRaceQueries() map[string]string {
 	return map[string]string{
 		racesList: `
-			SELECT 
-				id, 
-				meeting_id, 
-				name, 
-				number, 
-				visible, 
-				advertised_start_time 
+			SELECT
+				id,
+				meeting_id,
+				name,
+				number,
+				visible,
+				advertised_start_time
 			FROM races
 		`,
 	}

--- a/racing/go.mod
+++ b/racing/go.mod
@@ -1,6 +1,6 @@
 module git.neds.sh/matty/entain/racing
 
-go 1.16
+go 1.20
 
 require (
 	github.com/golang/protobuf v1.4.3
@@ -12,4 +12,12 @@ require (
 	google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.1.0
 	google.golang.org/protobuf v1.25.1-0.20201208041424-160c7477e0e8
 	syreclabs.com/go/faker v1.2.3
+)
+
+require (
+	github.com/ghodss/yaml v1.0.0 // indirect
+	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b // indirect
+	golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c // indirect
+	golang.org/x/text v0.3.5 // indirect
+	gopkg.in/yaml.v2 v2.3.0 // indirect
 )


### PR DESCRIPTION
This allows modern features of go, like the slices package, to be used by the protoc generator